### PR TITLE
Make the upload timeout for a script configurable

### DIFF
--- a/config/task-runner.php
+++ b/config/task-runner.php
@@ -31,4 +31,7 @@ return [
         'enabled' => env('TASK_RUNNER_PERSISTENT_FAKE', false),
         'storage_root' => storage_path('framework/testing/task-runner'),
     ],
+
+    // The default timeout for uploading script file to server in seconds
+    'upload_timeout' => 10,
 ];

--- a/src/RemoteProcessRunner.php
+++ b/src/RemoteProcessRunner.php
@@ -141,6 +141,7 @@ class RemoteProcessRunner
      *
      * @param  string  $filename
      * @param  string  $contents
+     * @param  int  $timeout
      */
     public function upload($filename, $contents): self
     {
@@ -156,7 +157,7 @@ class RemoteProcessRunner
         ]);
 
         $output = $this->processRunner->run(
-            FacadesProcess::command($command)->timeout(10)
+            FacadesProcess::command($command)->timeout(config('task-runner.upload_timeout'))
         );
 
         if ($output->isTimeout() || $output->getExitCode() !== 0) {

--- a/src/TaskDispatcher.php
+++ b/src/TaskDispatcher.php
@@ -80,7 +80,7 @@ class TaskDispatcher
      */
     private function runOnConnection(PendingTask $pendingTask): ProcessOutput
     {
-        /** @var RemoteProcessRunner */
+        /** @var RemoteProcessRunner $runner */
         $runner = app()->makeWith(
             RemoteProcessRunner::class,
             ['connection' => $pendingTask->getConnection(), 'processRunner' => $this->processRunner]


### PR DESCRIPTION
Sometime using scp to upload script file to a server very slow, I think 10 seconds is a bit short. So if we could make it configurable that's should be easier.
I'm not sure this quite the right way, but I think that make sense the idea